### PR TITLE
Fixed children retrieving from python collections by javascript.

### DIFF
--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -273,6 +273,14 @@ void CPythonObject::NamedGetter(v8::Local<v8::String> prop, const v8::PropertyCa
 
   if (PyGen_Check(obj.ptr())) CALLBACK_RETURN(v8::Undefined(info.GetIsolate()));
 
+  if (::PyMapping_Check(obj.ptr()) &&
+      ::PyMapping_HasKeyString(obj.ptr(), *name))
+  {
+    py::object result(py::handle<>(::PyMapping_GetItemString(obj.ptr(), *name)));
+
+    if (!result.is_none()) CALLBACK_RETURN(Wrap(result));
+  }
+
   PyObject *value = ::PyObject_GetAttrString(obj.ptr(), *name);
 
   if (!value)
@@ -288,15 +296,7 @@ void CPythonObject::NamedGetter(v8::Local<v8::String> prop, const v8::PropertyCa
         py::throw_error_already_set();
       }
     }
-
-    if (::PyMapping_Check(obj.ptr()) &&
-        ::PyMapping_HasKeyString(obj.ptr(), *name))
-    {
-      py::object result(py::handle<>(::PyMapping_GetItemString(obj.ptr(), *name)));
-
-      if (!result.is_none()) CALLBACK_RETURN(Wrap(result));
-    }
-
+    
     CALLBACK_RETURN(v8::Handle<v8::Value>());
   }
 


### PR DESCRIPTION
I've stuck with a problem recently with python collections and accessing them from javascript.

Say you have a JSON object (python dict)
```
{
    "a": 5, 
    "b": 10, 
    "items": [1, 2, 3]
}
```

When you pass it to javascript, it has a problem accessing some fields from it. 
For example, if you would like to print whole python dict from javascript, it prints OK, but if you try to access some childs, corresponding methods may be returned instead.

For example, dict has a method `items`. So if you try to access `dict["items"]` from javascript, you will end up with a reference to such method, instead of child with name "items".

This pull request reverses the order of querying items from python object: first, if the object is a python collection, it tries to pull that item. Then, a corresponding field is tried to be pulled.

I understand that there would be no way to access function `dict.items` from now on, if there's a child with such name. But this problem only occurs to python collections, and this method is kinda useless since `for (var i in dict)` gives what you want. Also, printing whole dict returns childs instead of methods, so return `[1, 2, 3]` instead of `[Function function]` should be kinda expected result.