### PR TITLE
Added timeout argument to limit javascript function call time

### DIFF
--- a/PyV8.py
+++ b/PyV8.py
@@ -115,7 +115,13 @@ class JSError(Exception):
     def frames(self):
         return self.parse_stack(self.stackTrace)
 
+
+class JSTimeoutError(Exception):
+    pass
+
+
 _PyV8._JSError._jsclass = JSError
+_PyV8._JSTimeoutError._jsclass = JSTimeoutError
 
 JSObject = _PyV8.JSObject
 JSNull = _PyV8.JSNull

--- a/src/Context.h
+++ b/src/Context.h
@@ -66,9 +66,9 @@ public:
   bool HasOutOfMemoryException(void) { v8::HandleScope handle_scope(v8::Isolate::GetCurrent()); return Handle()->HasOutOfMemoryException(); }
 
   py::object Evaluate(const std::string& src, const std::string name = std::string(),
-                      int line = -1, int col = -1, py::object precompiled = py::object());
+                      int line = -1, int col = -1, py::object precompiled = py::object(), long timeout = 0);
   py::object EvaluateW(const std::wstring& src, const std::wstring name = std::wstring(),
-                       int line = -1, int col = -1, py::object precompiled = py::object());
+                       int line = -1, int col = -1, py::object precompiled = py::object(), long timeout = 0);
 
   static py::object GetEntered(void);
   static py::object GetCurrent(void);

--- a/src/Exception.cpp
+++ b/src/Exception.cpp
@@ -76,6 +76,13 @@ void CJavascriptException::Expose(void)
     ExceptionTranslator::Construct, py::type_id<CJavascriptException>());
 }
 
+void CJavascriptTimeoutException::Expose(void)
+{
+  py::class_<CJavascriptTimeoutException >("_JSTimeoutError", py::no_init);
+    
+  py::register_exception_translator<CJavascriptTimeoutException>(ExceptionTranslator::TranslateTimeout);
+}
+
 CJavascriptStackTracePtr CJavascriptStackTrace::GetCurrentStackTrace(
   v8::Isolate *isolate, int frame_limit, v8::StackTrace::StackTraceOptions options)
 {
@@ -390,6 +397,22 @@ void ExceptionTranslator::Translate(CJavascriptException const& ex)
 
     ::PyErr_SetObject(clazz.ptr(), py::incref(err.ptr()));
   }
+}
+
+void ExceptionTranslator::TranslateTimeout(CJavascriptTimeoutException const& ex)
+{
+  CPythonGIL python_gil;
+
+  // Boost::Python doesn't support inherite from Python class,
+  // so, just use some workaround to throw our custom exception
+  //
+  // http://www.language-binding.net/pyplusplus/troubleshooting_guide/exceptions/exceptions.html
+
+  py::object impl(ex);
+  py::object clazz = impl.attr("_jsclass");
+  py::object err = clazz(impl);
+
+  ::PyErr_SetObject(clazz.ptr(), py::incref(err.ptr()));
 }
 
 void *ExceptionTranslator::Convertible(PyObject* obj)

--- a/src/Exception.h
+++ b/src/Exception.h
@@ -19,10 +19,12 @@
 #define END_HANDLE_JAVASCRIPT_EXCEPTION if (try_catch.HasCaught()) CJavascriptException::ThrowIf(v8::Isolate::GetCurrent(), try_catch);
 
 class CJavascriptException;
+class CJavascriptTimeoutException;
 
 struct ExceptionTranslator
 {
   static void Translate(CJavascriptException const& ex);
+  static void TranslateTimeout(CJavascriptTimeoutException const& ex);
 
   static void *Convertible(PyObject* obj);
   static void Construct(PyObject* obj, py::converter::rvalue_from_python_stage1_data* data);
@@ -178,3 +180,21 @@ public:
 
   static void Expose(void);
 };
+
+
+class CJavascriptTimeoutException : public std::runtime_error
+{
+public:
+  CJavascriptTimeoutException(const std::string& msg) :
+    std::runtime_error(msg)
+  {
+  }
+  
+  CJavascriptTimeoutException(const CJavascriptTimeoutException& ex)
+    : std::runtime_error(ex.what())
+  {
+  }
+
+  static void Expose(void);
+};
+

--- a/src/PyV8.cpp
+++ b/src/PyV8.cpp
@@ -12,6 +12,7 @@
 BOOST_PYTHON_MODULE(_PyV8)
 {
   CJavascriptException::Expose();
+  CJavascriptTimeoutException::Expose();
   CWrapper::Expose(); 
   CContext::Expose();
 #ifdef SUPPORT_AST

--- a/src/Wrapper.cpp
+++ b/src/Wrapper.cpp
@@ -15,6 +15,9 @@
 #include "Context.h"
 #include "Utils.h"
 
+#include <unistd.h>
+#include <signal.h>
+
 #define TERMINATE_EXECUTION_CHECK(returnValue) \
   if(v8::V8::IsExecutionTerminating()) { \
     ::PyErr_Clear(); \
@@ -112,12 +115,14 @@ void CWrapper::Expose(void)
     .def("apply", &CJavascriptFunction::ApplyPython,
          (py::arg("self"),
           py::arg("args") = py::list(),
-          py::arg("kwds") = py::dict()),
+          py::arg("kwds") = py::dict(),
+          py::arg("timeout") = py::long_(0)),
           "Performs a function call using the parameters.")
     .def("invoke", &CJavascriptFunction::Invoke,
           (py::arg("args") = py::list(),
-           py::arg("kwds") = py::dict()),
-          "Performs a binding method call using the parameters.")
+           py::arg("kwds") = py::dict(),
+           py::arg("timeout") = py::long_(0)),
+           "Performs a binding method call using the parameters.")
 
     .def("setName", &CJavascriptFunction::SetName)
 
@@ -1656,22 +1661,78 @@ py::object CJavascriptFunction::CreateWithArgs(CJavascriptFunctionPtr proto, py:
   return CJavascriptObject::Wrap(result);
 }
 
-py::object CJavascriptFunction::ApplyJavascript(CJavascriptObjectPtr self, py::list args, py::dict kwds)
+static bool ApplyJavascriptTimeout = false;
+
+void TerminateExecution(int sig)
 {
-  CHECK_V8_CONTEXT();
-
-  v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
-
-  return Call(self->Object(), args, kwds);
+    ApplyJavascriptTimeout = true;
+    v8::V8::TerminateExecution(v8::Isolate::GetCurrent());
 }
 
-py::object CJavascriptFunction::ApplyPython(py::object self, py::list args, py::dict kwds)
+inline void SetupAlarmHook(long timeout)
+{
+    ApplyJavascriptTimeout = false;
+    signal(SIGALRM, TerminateExecution);
+    ualarm((useconds_t)(timeout * 1000), (useconds_t)0);
+}
+
+inline void CheckAlarm()
+{
+    signal(SIGALRM, SIG_IGN);
+    ualarm((useconds_t)0, (useconds_t)0);
+    
+    if (ApplyJavascriptTimeout)
+    {
+        ApplyJavascriptTimeout = false;
+        
+        throw CJavascriptTimeoutException("Javascript function call timeout");
+    }
+}
+
+py::object CJavascriptFunction::ApplyJavascript(CJavascriptObjectPtr self, py::list args, py::dict kwds, py::long_ timeout)
 {
   CHECK_V8_CONTEXT();
 
   v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
+  
+  long timeout_ = py::extract<long>(timeout);
+  
+  if (timeout_ > 0)
+  {
+     SetupAlarmHook(timeout_);
+  }
+  
+  py::object result = Call(self->Object(), args, kwds);
+  
+  if (timeout_ > 0)
+  {
+     CheckAlarm();
+  }
+  
+  return result;
+}
 
-  return Call(CPythonObject::Wrap(self)->ToObject(), args, kwds);
+py::object CJavascriptFunction::ApplyPython(py::object self, py::list args, py::dict kwds, py::long_ timeout)
+{
+  CHECK_V8_CONTEXT();
+
+  v8::HandleScope handle_scope(v8::Isolate::GetCurrent());
+  
+  long timeout_ = py::extract<long>(timeout);
+  
+  if (timeout_ > 0)
+  {
+     SetupAlarmHook(timeout_);
+  }
+
+  py::object result = Call(CPythonObject::Wrap(self)->ToObject(), args, kwds);
+  
+  if (timeout_ > 0)
+  {
+     CheckAlarm();
+  }
+  
+  return result;
 }
 
 py::object CJavascriptFunction::Invoke(py::list args, py::dict kwds)

--- a/src/Wrapper.h
+++ b/src/Wrapper.h
@@ -191,8 +191,8 @@ public:
   static py::object CallWithArgs(py::tuple args, py::dict kwds);
   static py::object CreateWithArgs(CJavascriptFunctionPtr proto, py::tuple args, py::dict kwds);
 
-  py::object ApplyJavascript(CJavascriptObjectPtr self, py::list args, py::dict kwds);
-  py::object ApplyPython(py::object self, py::list args, py::dict kwds);
+  py::object ApplyJavascript(CJavascriptObjectPtr self, py::list args, py::dict kwds, py::long_ timeout);
+  py::object ApplyPython(py::object self, py::list args, py::dict kwds, py::long_ timeout);
   py::object Invoke(py::list args, py::dict kwds);
 
   const std::string GetName(void) const;


### PR DESCRIPTION
So recently I faced the problem that there's no way to limit function call time in any way.

For example, if you run this simple javascript code from python:
```javascript
while(true);
```
You will end up with infinite loop indeed, with no way exit that from python code, except kill the whole process.

That patch affects only `apply` method of javascript function object so it now has such signature:
```cpp
apply(this, args = [], kwargs = {}, timeout = 0)
```
And the code that can handle call 500ms timeout:
```python
try:
    some_function.apply(some_function, [], {}, 500L)
except JSTimeoutError:
    raise RuntimeError("Function call timeout!")
```

Under the hood, it uses `SIGALRM` and `v8::V8::TerminateExecution` to kill the running code gracefully. 

Why don't just use `SIGALRM` on python side? Python cannot catch `SIGALRM` while `C` code is executing.