### PR TITLE
Making the octal number compatible with Py3

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -520,7 +520,7 @@ def generate_probes():
         print("INFO: automatic make the build folder: %s" % build_path)
 
         try:
-            os.makedirs(build_path, 0755)
+            os.makedirs(build_path, 0o755)
         except os.error as ex:
             print("WARN: fail to create the build folder, %s" % ex)
 


### PR DESCRIPTION
Py3 interprets the octal numbers in a different way than Py2 which is `0o<octal_number>` as compared to `0<octal_number>` in Py2